### PR TITLE
Used Requests package (listed in docs/requirements.txt) to determine …

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@
 
 import acx2
 import pyatomdb
-import curl
+import requests
 import os
 import shutil
 import time
@@ -111,8 +111,9 @@ else:
 
 
   if install=='yes':
-    a=curl.Curl()
-    version=a.get('%s/releases/LATEST_ACX'%(pyatomdb.const.FTPPATH))[:-1].decode(encoding='ascii')
+    r=requests.get('%s/releases/LATEST_ACX'%(pyatomdb.const.FTPPATH))
+    r.encoding = 'ascii'
+    version = r.text.partition('\n')[0]
     userprefs = pyatomdb.util.load_user_prefs(adbroot=adbroot)
     userid = userprefs['USERID']
     userprefs['LASTCXVERSIONCHECK'] = time.time()


### PR DESCRIPTION
…LATEST_ACX version in __init__.py to allow download_acx2_emissivity_files() to be called; removed 'import curl'.

`import __init__` gave error `ModuleNotFoundError: No module named 'curl'`. While pycurl is listed as a requirement for pyatomdb, it is not listed for ACX2. Installing pycurl did not resolve, nor curl from condaforge, and it was unclear if another python curl package was intended.

ACX2 emissivity files were not being installed by `__init__.py` with setups on two machines including Miniconda3 for both MacOS Intel x86 and macOS Apple Silicon ARM, and having HEASoft setup with PyXspec tested successfully.

Retrieved and placed ACX2 emissivity files manually with success. Thought I would propose this change though based on inclusion of `requests` package in docs/requirements.txt

After switching to Requests package, calling `pip install -e .` inside of the acx2 directory (containing setup.py) successfully installed acx2, and once in the Python interpreter, `import acx2_xspec` now lead to ACX2 emissivity files being installed successfully.

Edit; formatting, mentioning pycurl